### PR TITLE
fix: bug in bychunk logic

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -30,10 +30,7 @@ bychunk <- function(file_format, path_to_table, path_to_parquet, chunk_size, ski
                     n_max = chunk_size)
   }
 
-  not_completed <- nrow(tbl) != 0
-
-  if (isTRUE(not_completed)) {
-
+  if (nrow(tbl) != 0) {
     parquetname <- paste0(gsub("\\..*","",sub(".*/","", path_to_table)))
     parquetizename <- paste0(parquetname,sprintf("%d",skip+1),"-",sprintf("%d",skip+chunk_size),".parquet")
 
@@ -41,9 +38,9 @@ bychunk <- function(file_format, path_to_table, path_to_parquet, chunk_size, ski
                   sink = file.path(path_to_parquet,
                                    parquetizename)
     )
-
     cli_alert_success("\nThe {file_format} file is available in parquet format under {path_to_parquet}/{parquetizename}")
   }
 
-  return(not_completed)
+  completed <- nrow(tbl) < chunk_size
+  return(!completed)
 }

--- a/tests/testthat/test-bychunk.R
+++ b/tests/testthat/test-bychunk.R
@@ -29,7 +29,7 @@ test_that("Checks bychunk works for SAS file", {
 
   expect_equal(
     test_data3,
-    TRUE)
+    FALSE)
 
   test_data4 <- bychunk(file_format = "SAS", path_to_table = system.file("examples","iris.sas7bdat", package = "haven"),
                        path_to_parquet = "Data",
@@ -69,7 +69,7 @@ test_that("Checks bychunk works for SPSS file", {
 
   expect_equal(
     test_data3,
-    TRUE)
+    FALSE)
 
   test_data4 <- bychunk(file_format = "SPSS", path_to_table = system.file("examples","iris.sav", package = "haven"),
                        path_to_parquet = "Data",
@@ -109,7 +109,7 @@ test_that("Checks bychunk works for Stata file", {
 
   expect_equal(
     test_data3,
-    TRUE)
+    FALSE)
 
   test_data4 <- bychunk(file_format = "Stata", path_to_table = system.file("examples","iris.dta", package = "haven"),
                        path_to_parquet = "Data",


### PR DESCRIPTION
parquetize::bychunk try to read after the end of the file. 

On some files it works, on other it doesn't.

On fhe file https://www2.census.gov/programs-surveys/ahs/2021/AHS%202021%20National%20PUF%20v1.0%20Flat%20SAS.zip it doesn't :

```
> sas <- haven::read_sas("ahs2021n.sas7bdat")
> nrow(sas)
[1] 64141
> parquetize::table_to_parquet("ahs2021n.sas7bdat", "tmp/2", by_chunk = TRUE, chunk_size = 10000)
✔ The SAS file is available in parquet format under tmp/2/ahs2021n1-10000.parquet
✔ The SAS file is available in parquet format under tmp/2/ahs2021n10001-20000.parquet
✔ The SAS file is available in parquet format under tmp/2/ahs2021n20001-30000.parquet
✔ The SAS file is available in parquet format under tmp/2/ahs2021n30001-40000.parquet
✔ The SAS file is available in parquet format under tmp/2/ahs2021n40001-50000.parquet
✔ The SAS file is available in parquet format under tmp/2/ahs2021n50001-60000.parquet
✔ The SAS file is available in parquet format under tmp/2/ahs2021n60001-70000.parquet
Error: Failed to parse /home/nc/travail/R/Rexploration/rdata/sas/ahs2021n.sas7bdat: Invalid file, or file has unsupported features.
```