### PR TITLE
Feature/allow chunk compression

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,11 @@
 # parquetize devel
 
-This release allow the user to pass argument to write_parquet when using
-by_chunk (in the ellipsis). Can be used for example to pass `compression` and
-`compression_level`
+This release includes :  
 
-Passing `by_chunk=TRUE` and `partition=yes` to `table_to_parquet` is no longer
+- The functionality for users to pass argument to `write_parquet()` when using
+by_chunk argument (in the ellipsis). Can be used for example to pass `compression` and
+`compression_level`.
+_ Passing `by_chunk=TRUE` and `partition=yes` to `table_to_parquet()` is no longer 
 possible.
 
 # parquetize 0.5.4

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,7 @@
 This release includes :  
 
 - The functionality for users to pass argument to `write_parquet()` when using
-by_chunk argument (in the ellipsis). Can be used for example to pass `compression` and
-`compression_level`.
+by_chunk argument (in the ellipsis). Can be used for example to pass `compression` and `compression_level`.
 _ Passing `by_chunk=TRUE` and `partition=yes` to `table_to_parquet()` is no longer 
 possible.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# parquetize devel
+
+This release allow the user to pass argument to write_parquet when using
+by_chunk (in the ellipsis). Can be used for example to pass `compression` and
+`compression_level`
+
+Passing `by_chunk=TRUE` and `partition=yes` to `table_to_parquet` is no longer
+possible.
+
+# parquetize 0.5.4
+
+This release fix an error when converting a sas file by chunk.
+
 # parquetize 0.5.3
 
 This release includes :  

--- a/R/table_to_parquet.R
+++ b/R/table_to_parquet.R
@@ -73,6 +73,18 @@
 #'   encoding = "utf-8"
 #' )
 #'
+#' # Reading SAS file by chunk and conversion to multiple files with zstd
+#' # compression level 10
+#'
+#' table_to_parquet(
+#'   path_to_table = system.file("examples","iris.sas7bdat", package = "haven"),
+#'   path_to_parquet = tempdir(),
+#'   by_chunk = TRUE,
+#'   chunk_size = 50,
+#'   compression = "zstd",
+#'   compression_level = 10
+#' )
+#'
 #' # Conversion from a SAS file to a single parquet file and select only
 #' #few columns  :
 #'
@@ -263,9 +275,9 @@ table_to_parquet <- function(
 
     }
 
-    if (isTRUE(bychunk(file_format = file_format, path_to_table, path_to_parquet, skip = skip, chunk_size = chunk_size))) {
+    if (isTRUE(bychunk(file_format = file_format, path_to_table, path_to_parquet, skip = skip, chunk_size = chunk_size, ...))) {
 
-      Recall(path_to_table, path_to_parquet, by_chunk=TRUE, skip = skip + chunk_size, chunk_size = chunk_size)
+      Recall(path_to_table, path_to_parquet, by_chunk=TRUE, skip = skip + chunk_size, chunk_size = chunk_size, ...)
 
     }
 

--- a/R/table_to_parquet.R
+++ b/R/table_to_parquet.R
@@ -146,9 +146,9 @@ table_to_parquet <- function(
     stop("")
   }
 
-  # If by_chunk argument is TRUE and partition argument is equal to "yes" we fail
+  # If by_chunk argument is TRUE and partition argument is equal to "yes" it fails
   if (by_chunk==TRUE & partition == "yes") {
-  cli_alert_danger("Be careful, when by_chunk is TRUE partition and partitioning can not be used")
+  cli_alert_danger("Be careful, when by_chunk is TRUE, partition and partitioning can not be used")
     stop("")
   }
 

--- a/R/table_to_parquet.R
+++ b/R/table_to_parquet.R
@@ -28,7 +28,7 @@
 #' @param skip By default 0. This argument must be filled in if `by_chunk` is TRUE. Number of lines to ignore when converting.
 #' @param partition string ("yes" or "no" - by default) that indicates whether you want to create a partitioned parquet file.
 #' If "yes", `"partitioning"` argument must be filled in. In this case, a folder will be created for each modality of the variable filled in `"partitioning"`.
-#' Be careful, if `by_chunk` argument is not NULL then a single parquet file will be created.
+#' Be careful, this argument can not be "yes" if `by_chunk` argument is not NULL.
 #' @param encoding string that indicates the character encoding for the input file.
 #' @param ... additional format-specific arguments,  see \href{https://arrow.apache.org/docs/r/reference/write_parquet.html}{arrow::write_parquet()}
 #'  and \href{https://arrow.apache.org/docs/r/reference/write_dataset.html}{arrow::write_dataset()} for more informations.
@@ -134,9 +134,10 @@ table_to_parquet <- function(
     stop("")
   }
 
-  # If by_chunk argument is TRUE and partition argument is equal to "yes" then partition is forced to "no"
+  # If by_chunk argument is TRUE and partition argument is equal to "yes" we fail
   if (by_chunk==TRUE & partition == "yes") {
-    partition <- "no"
+  cli_alert_danger("Be careful, when by_chunk is TRUE partition and partitioning can not be used")
+    stop("")
   }
 
   parquetname <- paste0(gsub("\\..*","",sub(".*/","", path_to_table)),".parquet")

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -10,7 +10,7 @@
 #'
 #'
 #' @noRd
-bychunk <- function(file_format, path_to_table, path_to_parquet, chunk_size, skip) {
+bychunk <- function(file_format, path_to_table, path_to_parquet, chunk_size, skip, ...) {
 
   if (file_format %in% c("SAS")) {
 
@@ -36,7 +36,8 @@ bychunk <- function(file_format, path_to_table, path_to_parquet, chunk_size, ski
 
     write_parquet(tbl,
                   sink = file.path(path_to_parquet,
-                                   parquetizename)
+                                   parquetizename),
+                  ...
     )
     cli_alert_success("\nThe {file_format} file is available in parquet format under {path_to_parquet}/{parquetizename}")
   }

--- a/man/table_to_parquet.Rd
+++ b/man/table_to_parquet.Rd
@@ -31,7 +31,7 @@ table_to_parquet(
 
 \item{partition}{string ("yes" or "no" - by default) that indicates whether you want to create a partitioned parquet file.
 If "yes", `"partitioning"` argument must be filled in. In this case, a folder will be created for each modality of the variable filled in `"partitioning"`.
-Be careful, if `by_chunk` argument is not NULL then a single parquet file will be created.}
+Be careful, this argument can not be "yes" if `by_chunk` argument is not NULL.}
 
 \item{encoding}{string that indicates the character encoding for the input file.}
 
@@ -90,6 +90,18 @@ table_to_parquet(
   by_chunk = TRUE,
   chunk_size = 50,
   encoding = "utf-8"
+)
+
+# Reading SAS file by chunk and conversion to multiple files with zstd
+# compression level 10
+
+table_to_parquet(
+  path_to_table = system.file("examples","iris.sas7bdat", package = "haven"),
+  path_to_parquet = tempdir(),
+  by_chunk = TRUE,
+  chunk_size = 50,
+  compression = "zstd",
+  compression_level = 10
 )
 
 # Conversion from a SAS file to a single parquet file and select only

--- a/tests/testthat/_snaps/table_to_parquet.md
+++ b/tests/testthat/_snaps/table_to_parquet.md
@@ -160,16 +160,16 @@
       v The SAS file is available in parquet format under Data_test
       Writing data...
 
-# Checks message is displayed with SAS by adding chunk_size, partition and partitioning argument
+# Checks we fail with SAS by adding chunk_size, partition and partitioning argument
 
     Code
       table_to_parquet(path_to_table = system.file("examples", "iris.sas7bdat",
         package = "haven"), path_to_parquet = "Data_test", by_chunk = TRUE,
       chunk_size = 50, partition = "yes", partitioning = "Species")
     Message <cliMessage>
-      v The SAS file is available in parquet format under Data_test/iris1-50.parquet
-      v The SAS file is available in parquet format under Data_test/iris51-100.parquet
-      v The SAS file is available in parquet format under Data_test/iris101-150.parquet
+      x Be careful, when by_chunk is TRUE partition and partitioning can not be used
+    Error <simpleError>
+      
 
 # Checks message is displayed with SAS by adding chunk_size argument
 

--- a/tests/testthat/test-table_to_parquet.R
+++ b/tests/testthat/test-table_to_parquet.R
@@ -104,7 +104,7 @@ test_that("Checks message is displayed with by adding partition and partitioning
   )
 })
 
-test_that("Checks we fail with SAS by adding chunk_size, partition and partitioning argument", {
+test_that("Checks it fails with SAS by adding chunk_size, partition and partitioning argument", {
 
   expect_snapshot(
     table_to_parquet(

--- a/tests/testthat/test-table_to_parquet.R
+++ b/tests/testthat/test-table_to_parquet.R
@@ -104,7 +104,7 @@ test_that("Checks message is displayed with by adding partition and partitioning
   )
 })
 
-test_that("Checks message is displayed with SAS by adding chunk_size, partition and partitioning argument", {
+test_that("Checks we fail with SAS by adding chunk_size, partition and partitioning argument", {
 
   expect_snapshot(
     table_to_parquet(
@@ -114,7 +114,8 @@ test_that("Checks message is displayed with SAS by adding chunk_size, partition 
       chunk_size = 50,
       partition = "yes",
       partitioning =  "Species"
-    )
+    ),
+    error = TRUE
   )
 })
 


### PR DESCRIPTION
In 0.5.4, ellipsis arguments passed to table_to_parquet when by_chunk is TRUE are silently ignore.

This PR allow passing them (so that we can use compression and compression_level for example)