### PR TITLE
fix: remove single quotes in SQL statement

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# parquetize (WIP)
+
+This release includes :
+
+- bugfix by @leungi: remove single quotes in SQL statement thatgenerates incorrect SQL syntax for connection of type Microsoft SQL Server #45
+
+
 # parquetize 0.5.6.1
 
 This release includes :

--- a/R/get_partitions.R
+++ b/R/get_partitions.R
@@ -29,5 +29,5 @@ get_partitions <- function(conn, table, column) {
     cli_abort("Be careful, the argument column must be filled in", class = "parquetize_missing_argument")
   }
 
-  DBI::dbGetQuery(conn, glue::glue("SELECT distinct({`column`}) FROM '{`table`}'", .con = conn))[,1]
+  DBI::dbGetQuery(conn, glue::glue("SELECT distinct({`column`}) FROM {`table`}", .con = conn))[,1]
 }


### PR DESCRIPTION
#### Issue
With reference to the code chuck below, the single quotes around `table` variable generates incorrect SQL syntax for connection of type Microsoft SQL Server.

```{r}
con <- DBI::dbConnect(
    odbc::odbc(),
    Driver   = my_driver,
    Server   = my_server,
    Database = my_database,
    Port     = my_port,
    Trusted_Connection = "Yes"
  )

class(con)
#> [1] "Microsoft SQL Server"
#> attr(,"package")
#> [1] ".GlobalEnv"

get_partitions(con, "my_table", "my_column")
#> Error: nanodbc/nanodbc.cpp:1617: 42000: [Microsoft][ODBC SQL Server Driver][SQL Server]Incorrect syntax near 'my_table'.  [Microsoft][ODBC SQL Server Driver][SQL Server]Statement(s) could not be prepared. 
<SQL> 'SELECT distinct(my_column) FROM 'my_table''
```

#### Reference Code Chunk
 https://github.com/ddotta/parquetize/blob/4523002dfc058504cf13daa02834f0ae80d9d988/R/get_partitions.R#L32, 